### PR TITLE
Change localhost port to 8080

### DIFF
--- a/client/src/sockets/socket.ts
+++ b/client/src/sockets/socket.ts
@@ -5,7 +5,7 @@ let socket: Socket;
 // Auto-select backend URL depending on environment
 const SOCKET_URL = import.meta.env.PROD
   ? "wss://hansitha-web-backend.onrender.com"
-  : "http://localhost:8080";
+  : "http://localhost:3000";
 
 export const connectSocket = () => {
   socket = io(SOCKET_URL, {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,9 +9,9 @@ export default defineConfig(({ mode }) => ({
 
   server: {
     host: "::",
-    port: 5173,
+    port: 8080,
     proxy: {
-      '/api': 'http://localhost:8080',
+      '/api': 'http://localhost:3000',
     }
   },
 

--- a/server/server.js
+++ b/server/server.js
@@ -269,7 +269,7 @@ app.post("/api/newsletter", async (req, res) => {
 });
 
 // Start Server
-const PORT = process.env.PORT || 8080;
+const PORT = process.env.PORT || 3000;
 server.listen(PORT, "0.0.0.0", () =>
   console.log(`🚀 Server running on port ${PORT}`)
 );


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Change client dev server port to 8080 by moving the backend server to port 3000 to resolve port conflicts.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The user requested to change the client's development port from 5173 to 8080. Since port 8080 was already in use by the backend server, the server's port was reconfigured to 3000 to prevent conflicts. All client-side references (proxy and socket connections) were updated to point to the new server port.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9306d6c-f608-49c2-8ce9-1bc0a7b1a246">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9306d6c-f608-49c2-8ce9-1bc0a7b1a246">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>